### PR TITLE
Filter out revtex's <job>Notes.bib files

### DIFF
--- a/src/ads2inspire/__init__.py
+++ b/src/ads2inspire/__init__.py
@@ -37,6 +37,11 @@ def parse_aux(aux_path):
     except:
         bib_path_strs = []
 
+    # Filter out revtex's <job>Notes.bib files
+    # This is kind of a hack... is there a better way?
+    revtex_Notes_name = aux_path.stem + "Notes"
+    bib_path_strs = [ path for path in bib_path_strs if path != revtex_Notes_name ]
+
     # And which citation keys were used
     cite_pat = re.compile("\\\\bibcite\\{(.*?)\\}")
 


### PR DESCRIPTION
This is never the file you want to read or write to.
This may however be a bit cavalier — what if somebody decided to name their tex and bib files `wonderful.tex` and `wonderfulNotes.bib`? I suspect this is impossible with revtex, but may be an edge case...