### PR TITLE
Add option to be able to filter ADS or (!INSPIRE).

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,13 +49,16 @@ python -m pip install "git+https://github.com/duetosymmetry/ads2inspire.git#egg=
 First latex/bibtex/latex your file, then run
 
 ```shell
-ads2inspire [--backup] auxfile.aux [texfile1.tex [texfile2.tex [...]]]
+ads2inspire [--backup] [--filter-type [ads|all]] auxfile.aux [texfile1.tex [texfile2.tex [...]]]
 ```
 
 If your main tex file is named `wonderful.tex`, then your auxfile will be named `wonderful.aux`.
 `ads2inspire` will read the aux file, query INSPIRE, then rewrite all the texfiles named on the
 command line, and append to the first bibtex file named in auxfile.  The option `--backup` will
-make the program write backups of the tex and bib files before rewriting them.
+make the program write backups of the tex and bib files before rewriting them.  The option
+`--filter-type` controls which keys to search for on INSPIRE: the default `"ads"` will only
+search for keys that look like ADS keys, while `"all"` will try all keys (aside from those that
+look like INSPIRE keys).
 
 ## Contributing
 
@@ -64,4 +67,5 @@ Please fork and send me PRs!
 
 TODO:
 - More testing
+- More filter types
 - more?

--- a/src/ads2inspire/__init__.py
+++ b/src/ads2inspire/__init__.py
@@ -129,6 +129,26 @@ def filter_ads_keys(cite_keys):
     return [key for key in cite_keys if ads_pat.match(key) is not None]
 
 
+def filter_not_insp_keys(cite_keys):
+    """Select keys that do not match the pattern of INSPIRE bibtex keys.
+
+    The current pattern to /not/ match is: `".*?:\d\d\d\d[a-z]{2,3}"`
+
+    Parameters
+    ----------
+    cite_keys: array of string
+      An array of bibtex keys
+
+    Returns
+    -------
+    not_insp_keys: array of string
+      The non-matching keys from cite_keys
+    """
+
+    insp_pat = re.compile(".*?:\d\d\d\d[a-z]{2,3}")
+    return [key for key in cite_keys if insp_pat.match(key) is None]
+
+
 def filter_matchable_fields(cite_keys, bib_dbs, desired_fields=["eprint", "doi"]):
     """Select bibtex entries which have certain desired fields.
 


### PR DESCRIPTION
This adds a cli option and the python code which enables it. Currently there are only two filter types available:
- `"ads"` which is the old behavior
- `"all"` which is all bibkeys that do not look like INSPIRE keys
I imagine others might want to implement their own filter types, or we can allow regexes on the commandline. The latter would require again changing the cli behavior, because we would want another string input aside from the Choice `"regex"` or similar.