### PR TITLE
feat: Use bumpversion to control version number

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,0 +1,6 @@
+[bumpversion]
+current_version = 0.2.0
+commit = True
+tag = True
+
+[bumpversion:file:setup.cfg]

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ extras_require = {
     ],
 }
 extras_require["develop"] = sorted(
-    set(extras_require["test"] + ["pre-commit", "twine"])
+    set(extras_require["test"] + ["pre-commit", "bumpversion", "twine"])
 )
 extras_require["complete"] = sorted(set(sum(extras_require.values(), [])))
 


### PR DESCRIPTION
# Description

Resolves #6 

This PR adds `bumpversion` to the 'develop' extra so that it is installed by default when a core dev begins work in a new virtual environment. The addition of the `.bumpversion.cfg` file then controls the version number of the library and tag creation. As a result, unless this is added into a CI system in later dates (c.f. [`pyhf`](https://github.com/scikit-hep/pyhf/blob/79984be837ef6e53bdd12a82163c34d47d507dba/.github/workflows/tag.yml)) `bumpversion` should only be run on `master` as the resulting commit and tag will need to be pushed up on `master`.

To control tag creation with `bumpversion` simply run

```
bumpversion <semantic version type>
```

where `<semantic version type>` is `major`, `minor`, or `patch`.

As an explicit example on this PR,

```
bumpversion patch
```

would result in

```diff
$ git show HEAD
commit 151ccfc6007db462e3b678d48db874d1191105e0 (HEAD -> feat/use-bumpversion, tag: v0.2.1)
Author: Matthew Feickert <matthew.feickert@cern.ch>
Date:   Wed Jul 8 00:16:41 2020 -0500

    Bump version: 0.2.0 → 0.2.1

diff --git a/.bumpversion.cfg b/.bumpversion.cfg
index e8fb4e9..aab6d8a 100644
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.2.0
+current_version = 0.2.1
 commit = True
 tag = True
 
diff --git a/setup.cfg b/setup.cfg
index 7709c4a..9d38331 100644
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = ads2inspire
-version = 0.2.0
+version = 0.2.1
 description = Replace ADS citations with the appropriate INSPIRE ones in latex and bibtex
 long_description = file: README.md
 long_description_content_type = text/markdown
```

## Suggested Squash and Merge Commit Message

```
* Add bumpversion to 'develop' extra
* Use bumpversion to control version number and tags
```
