### PR TITLE
docs: Add preferred BibTeX citation to README

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -4,3 +4,7 @@ commit = True
 tag = True
 
 [bumpversion:file:setup.cfg]
+
+[bumpversion:file:README.md]
+
+[bumpversion:file:.zenodo.json]

--- a/.zenodo.json
+++ b/.zenodo.json
@@ -1,0 +1,32 @@
+{
+    "description": "Replace ADS citations with the appropriate INSPIRE ones in latex and bibtex",
+    "license": "MIT",
+    "title": "duetosymmetry/ads2inspire: v0.2.0",
+    "version": "v0.2.0",
+    "upload_type": "software",
+    "creators": [
+        {
+            "affiliation": "University of Mississippi",
+            "name": "Leo C. Stein",
+            "orcid": "0000-0001-7559-9597"
+        },
+        {
+            "affiliation": "University of Illinois at Urbana-Champaign",
+            "name": "Matthew Feickert",
+            "orcid": "0000-0003-4124-7862"
+        }
+    ],
+    "access_right": "open",
+    "keywords": [
+      "latex",
+      "bibtex",
+      "bibliography"
+    ],
+    "related_identifiers": [
+        {
+            "scheme": "url",
+            "identifier": "https://github.com/duetosymmetry/ads2inspire/tree/v0.2.0",
+            "relation": "isSupplementTo"
+        }
+    ]
+}

--- a/README.md
+++ b/README.md
@@ -69,3 +69,17 @@ TODO:
 - More testing
 - More filter types
 - more?
+
+## Citation
+
+The preferred BibTeX entry for citation of `ads2inspire` is
+
+```
+@software{ads2inspire,
+  author = "{Stein, Leo C. and Feickert, Matthew}",
+  title = "{ads2inspire: v0.2.0}",
+  version = {v0.2.0},
+  doi = {10.5281/zenodo.3903987},
+  url = {https://github.com/duetosymmetry/ads2inspire},
+}
+```


### PR DESCRIPTION
Add a preferred BibTeX citation to README that gets updated with releases through `bumpversion`. Additionally, add control over metadata shown on Zenodo through `.zenodo.json`.

If this is merged in before a release named `v0.2.0` is made from the tag on GitHub then the Zenodo page for `ads2inspire` will reflect these metadata changes.

```
* Add preferred BibTeX citation to README
* Add .zenodo.json to control metadata for releases on Zenodo
* Control the citation information through bumpversion
```