### PR TITLE
docs: Update Matthew's affiliation to University of Wisconsin-Madison

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -11,7 +11,7 @@
             "orcid": "0000-0001-7559-9597"
         },
         {
-            "affiliation": "University of Illinois at Urbana-Champaign",
+            "affiliation": "University of Wisconsin-Madison",
             "name": "Matthew Feickert",
             "orcid": "0000-0003-4124-7862"
         }


### PR DESCRIPTION
* Matthew Feickert is a postdoc at University of Wisconsin-Madison as of June 2022.