### PR TITLE
fix: Use 'req@url' syntax to install from remote VCS

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ python -m pip install .
 In your Python environment run
 
 ```
-python -m pip install "git+https://github.com/duetosymmetry/ads2inspire.git#egg=ads2inspire"
+python -m pip install "ads2inspire@git+https://github.com/duetosymmetry/ads2inspire.git"
 ```
 
 ## Usage


### PR DESCRIPTION
* Use 'req@url' syntax when using pip to install from a remote git repository over 'url#egg=req' to avoid the use of #egg= fragments with a non-PEP 508 name. This will be required in pip v25.0+.
   - c.f. https://github.com/pypa/pip/pull/11617 for more details.